### PR TITLE
Add print statement for keyword documentation in tests

### DIFF
--- a/utest/test/api/test_plugin_documentation.py
+++ b/utest/test/api/test_plugin_documentation.py
@@ -31,6 +31,7 @@ class PluginDocumentation(unittest.TestCase):
         sl = SeleniumLibrary(
             plugins=f"{self.plugin_1}, {self.plugin_3};arg1=Text1;arg2=Text2"
         )
+        print(sl.get_keyword_documentation("__intro__"))  # add this
         verify(sl.get_keyword_documentation("__intro__"), self.reporter)
 
     @unittest.skipIf(WINDOWS, reason="ApprovalTest do not support different line feeds")


### PR DESCRIPTION
Added print statement to output keyword documentation for '__intro__' in test_many_plugins.